### PR TITLE
MMR related bug fixes.

### DIFF
--- a/src/fm77av/fdc/fm77avfdc.cpp
+++ b/src/fm77av/fdc/fm77avfdc.cpp
@@ -199,10 +199,14 @@ void FM77AVFDC::MakeReady(void)
 			   true==fm77avPtr->dmac.FDCtoMEM())
 			{
 				auto addr0=fm77avPtr->dmac.Address();
+				// The MMR segment 0 is always used regardless of the value set in the MMR-seg register when DMA accesses the memory.
+				uint8_t mmrseg_bkup = fm77avPtr->mainMemAcc.state.MMRSEG;
+				fm77avPtr->mainMemAcc.state.MMRSEG = 0;
 				for(unsigned int i=0; i<fm77avPtr->dmac.NumBytes() && i<state.data.size(); ++i)
 				{
 					fm77avPtr->mainMemAcc.StoreByte(addr0+i,state.data[i]);
 				}
+				fm77avPtr->mainMemAcc.state.MMRSEG = mmrseg_bkup;
 				fm77avPtr->dmac.SetDMAEnd(true);
 				fm77avPtr->dmac.SetIRQ(true);
 				fm77avPtr->dmac.SetBusy(false);
@@ -353,10 +357,14 @@ void FM77AVFDC::MakeReady(void)
 			   true==fm77avPtr->dmac.FDCtoMEM())
 			{
 				auto addr0=fm77avPtr->dmac.Address();
+				// The MMR segment 0 is always used regardless of the value set in the MMR-seg register when DMA accesses the memory.
+				uint8_t mmrseg_bkup = fm77avPtr->mainMemAcc.state.MMRSEG;
+				fm77avPtr->mainMemAcc.state.MMRSEG = 0;
 				for(unsigned int i=0; i<fm77avPtr->dmac.NumBytes() && i<state.data.size(); ++i)
 				{
 					fm77avPtr->mainMemAcc.StoreByte(addr0+i,state.data[i]);
 				}
+				fm77avPtr->mainMemAcc.state.MMRSEG = mmrseg_bkup;
 				fm77avPtr->dmac.SetDMAEnd(true);
 				fm77avPtr->dmac.SetIRQ(true);
 				fm77avPtr->dmac.SetBusy(false);

--- a/src/memory/fm77avmemory.cpp
+++ b/src/memory/fm77avmemory.cpp
@@ -1147,6 +1147,11 @@ void MainCPUAccess::WriteFD8x(uint16_t ioAddr,uint8_t data)
 	{
 		data&=0x7F;
 	}
+	// According to the FM77AC40EX/20EX Hardware Manual, unlike the other MMR registers, A19 and A18 are not effective on $FD8F.
+	if(FM77AVIO_MMR_F==ioAddr)
+	{
+		data&=0x3F;
+	}
 	state.MMR[state.MMRSEG][ioAddr-FM77AVIO_MMR_0]=data;
 	state.MMR[state.MMRSEG][ioAddr-FM77AVIO_MMR_0]<<=12;
 }


### PR DESCRIPTION
I reviewed the FM77AV40EX/20EX Hardware manual and found some inconsistencies in the code.

- A19 and A18 are not effective on MMR_F register. (p.28 Register map)
- FDC DMA always uses MMR SEG0 regardless of the value in the SEG register. (p.141 8.2.3 DMAC memory management)